### PR TITLE
Add observability hooks to agent class

### DIFF
--- a/examples/rails_bible_chat/DEBUG_PANEL.md
+++ b/examples/rails_bible_chat/DEBUG_PANEL.md
@@ -1,0 +1,147 @@
+# Debug Panel - Real-time Agent Observability
+
+The Bible Study Chat example now includes a real-time debug panel that displays all observability hooks as they fire during agent execution.
+
+## Features
+
+- **Floating, collapsible panel** in the bottom-right corner
+- **Real-time updates** via ActionCable WebSocket
+- **Color-coded hooks** for easy visual scanning
+- **JSON payload inspection** for each event
+- **Ephemeral events** - refreshes on page reload
+
+## Architecture
+
+### Backend (Rails)
+1. **ActionCable Setup**
+   - `app/channels/application_cable/connection.rb` - WebSocket connection handler
+   - `app/channels/debug_channel.rb` - Channel for broadcasting hook events
+
+2. **Agent Hooks**
+   - `app/agents/bible_study_agent.rb` - All 16 observability hooks configured
+   - Hooks broadcast events to the DebugChannel
+
+### Frontend (React + TypeScript)
+1. **DebugPanel Component**
+   - `app/frontend/components/DebugPanel.tsx` - Main panel component
+   - Connects to ActionCable on mount
+   - Auto-scrolls to latest event
+   - Collapsible and dismissible
+
+2. **Integration**
+   - Added to `app/frontend/pages/Conversations/Show.tsx`
+   - Receives events in real-time as user interacts with the chat
+
+## Hooks Displayed
+
+The panel shows all 16 hook types:
+
+### Session Lifecycle (Purple)
+- `on_session_start` - Agent initialized
+- `on_session_end` - Session explicitly ended
+
+### Turn Lifecycle (Blue)
+- `on_turn_start` - User message received
+- `on_turn_end` - Turn completed with usage stats
+
+### Response Lifecycle (Green)
+- `on_response_start` - API call begins
+- `on_response_end` - API call completes with usage
+- `on_response_chunk` - Streaming chunk received
+
+### Thinking (Pink)
+- `on_thinking_start` - Extended thinking begins
+- `on_thinking_end` - Thinking completes with content
+
+### Tool Execution (Orange)
+- `on_tool_start` - Tool begins execution
+- `on_tool_end` - Tool completes successfully
+- `on_tool_error` - Tool encounters error
+
+### Other Events
+- `on_message_added` (Indigo) - Message added to history
+- `on_iteration` (Yellow) - Tool loop iteration
+- `on_error` (Red) - Agent-level error
+- `on_stop` (Gray) - Execution stops
+
+## Setup
+
+### 1. Install Dependencies
+```bash
+npm install
+```
+
+This will install `@rails/actioncable` for WebSocket support.
+
+### 2. Start Rails Server
+```bash
+bin/rails server
+```
+
+ActionCable runs on the same port as the Rails server.
+
+### 3. Navigate to a Conversation
+Open http://localhost:3000/conversations and start a new chat.
+
+The debug panel will appear in the bottom-right corner and start showing events immediately.
+
+## Usage
+
+### Panel Controls
+- **Collapse/Expand**: Click the chevron icon
+- **Clear Events**: Click the trash icon
+- **Hide Panel**: Click the X icon (can be re-shown with "Show Debug Panel" button)
+
+### Event Inspection
+Each event displays:
+- **Hook name** (color-coded)
+- **Timestamp** (local time)
+- **Full JSON payload** with proper formatting
+
+### Example Event Flow
+
+When you send a message like "Tell me about John 3:16":
+
+```
+[on_turn_start] User message received
+[on_message_added] UserMessage added
+[on_response_start] API call begins
+[on_response_chunk] Text streaming...
+[on_tool_start] bible_lookup tool called
+[on_tool_end] bible_lookup returns data
+[on_message_added] ToolResponse added
+[on_response_start] API call with tool result
+[on_response_chunk] Final response streaming...
+[on_response_end] API complete (with usage stats)
+[on_turn_end] Turn complete (total tokens used)
+[on_stop] Execution complete
+```
+
+## Implementation Notes
+
+### Broadcast Safety
+The `broadcast_hook` method includes error handling to prevent broadcasting failures from breaking the agent:
+
+```ruby
+rescue => e
+  Rails.logger.error "Failed to broadcast hook #{hook_name}: #{e.message}"
+end
+```
+
+### Performance
+- Events are ephemeral (not persisted)
+- Panel auto-scrolls to latest event
+- Old events are kept in state until page reload or manual clear
+
+### Development Tips
+- Use the panel to understand agent execution flow
+- Inspect usage data to optimize token consumption
+- Monitor tool execution timing
+- Debug frontend vs backend tool routing
+
+## Future Enhancements
+- Persistent event storage
+- Event filtering by hook type
+- Export events to JSON
+- Performance metrics dashboard
+- Token cost calculator

--- a/examples/rails_bible_chat/app/agents/bible_study_agent.rb
+++ b/examples/rails_bible_chat/app/agents/bible_study_agent.rb
@@ -28,4 +28,40 @@ class BibleStudyAgent < ActiveIntelligence::Agent
 
   tool BibleReferenceTool
   tool ShowEmojiTool
+
+  # Observability hooks - broadcast all events to debug panel
+  on_session_start { |session| broadcast_hook('on_session_start', session.to_h) }
+  on_session_end { |session| broadcast_hook('on_session_end', session.to_h) }
+  on_turn_start { |turn| broadcast_hook('on_turn_start', turn.to_h) }
+  on_turn_end { |turn| broadcast_hook('on_turn_end', turn.to_h) }
+  on_response_start { |response| broadcast_hook('on_response_start', response.to_h) }
+  on_response_end { |response| broadcast_hook('on_response_end', response.to_h) }
+  on_response_chunk { |chunk| broadcast_hook('on_response_chunk', chunk.to_h) }
+  on_thinking_start { |thinking| broadcast_hook('on_thinking_start', thinking.to_h) }
+  on_thinking_end { |thinking| broadcast_hook('on_thinking_end', thinking.to_h) }
+  on_tool_start { |tool| broadcast_hook('on_tool_start', tool.to_h) }
+  on_tool_end { |tool| broadcast_hook('on_tool_end', tool.to_h) }
+  on_tool_error { |tool| broadcast_hook('on_tool_error', tool.to_h) }
+  on_message_added { |message| broadcast_hook('on_message_added', { type: message.class.name, content_preview: message.content&.to_s&.slice(0, 100) }) }
+  on_iteration { |iteration| broadcast_hook('on_iteration', iteration.to_h) }
+  on_error { |error_ctx| broadcast_hook('on_error', error_ctx.to_h) }
+  on_stop { |stop| broadcast_hook('on_stop', stop.to_h) }
+
+  private
+
+  def broadcast_hook(hook_name, payload)
+    return unless @conversation
+
+    DebugChannel.broadcast_to(
+      @conversation,
+      {
+        hook: hook_name,
+        payload: payload,
+        timestamp: Time.now.iso8601
+      }
+    )
+  rescue => e
+    # Don't let broadcasting errors break the agent
+    Rails.logger.error "Failed to broadcast hook #{hook_name}: #{e.message}"
+  end
 end

--- a/examples/rails_bible_chat/app/channels/application_cable/channel.rb
+++ b/examples/rails_bible_chat/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/examples/rails_bible_chat/app/channels/application_cable/connection.rb
+++ b/examples/rails_bible_chat/app/channels/application_cable/connection.rb
@@ -1,0 +1,9 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :conversation_id
+
+    def connect
+      self.conversation_id = request.params[:conversation_id]
+    end
+  end
+end

--- a/examples/rails_bible_chat/app/channels/debug_channel.rb
+++ b/examples/rails_bible_chat/app/channels/debug_channel.rb
@@ -1,0 +1,10 @@
+class DebugChannel < ApplicationCable::Channel
+  def subscribed
+    conversation = ActiveIntelligence::Conversation.find(params[:conversation_id])
+    stream_for conversation
+  end
+
+  def unsubscribed
+    # Cleanup when channel is closed
+  end
+end

--- a/examples/rails_bible_chat/app/frontend/components/DebugPanel.tsx
+++ b/examples/rails_bible_chat/app/frontend/components/DebugPanel.tsx
@@ -1,0 +1,170 @@
+import { useState, useEffect, useRef } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { ChevronDown, ChevronUp, X, Trash2 } from 'lucide-react'
+
+interface HookEvent {
+  id: string
+  hook: string
+  payload: any
+  timestamp: string
+}
+
+interface DebugPanelProps {
+  conversationId: number
+}
+
+export function DebugPanel({ conversationId }: DebugPanelProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false)
+  const [isVisible, setIsVisible] = useState(true)
+  const [events, setEvents] = useState<HookEvent[]>([])
+  const [cable, setCable] = useState<any>(null)
+  const eventsEndRef = useRef<HTMLDivElement>(null)
+
+  const scrollToBottom = () => {
+    eventsEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  useEffect(() => {
+    scrollToBottom()
+  }, [events])
+
+  useEffect(() => {
+    let channel: any = null
+    let consumer: any = null
+
+    // Connect to ActionCable
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const wsUrl = `${protocol}//${window.location.host}/cable?conversation_id=${conversationId}`
+
+    // Dynamic import of ActionCable
+    import('@rails/actioncable').then((actionCableModule) => {
+      const actionCable = actionCableModule.default || actionCableModule
+      consumer = actionCable.createConsumer(wsUrl)
+
+      channel = consumer.subscriptions.create(
+        { channel: 'DebugChannel', conversation_id: conversationId },
+        {
+          received: (data: { hook: string; payload: any; timestamp: string }) => {
+            const event: HookEvent = {
+              id: `${Date.now()}-${Math.random()}`,
+              hook: data.hook,
+              payload: data.payload,
+              timestamp: data.timestamp
+            }
+            setEvents(prev => [...prev, event])
+          }
+        }
+      )
+
+      setCable(consumer)
+    })
+
+    return () => {
+      if (channel) channel.unsubscribe()
+      if (consumer) consumer.disconnect()
+    }
+  }, [conversationId])
+
+  const clearEvents = () => {
+    setEvents([])
+  }
+
+  if (!isVisible) return null
+
+  // Hook color mapping for visual distinction
+  const getHookColor = (hookName: string): string => {
+    if (hookName.includes('session')) return 'text-purple-600'
+    if (hookName.includes('turn')) return 'text-blue-600'
+    if (hookName.includes('response')) return 'text-green-600'
+    if (hookName.includes('tool')) return 'text-orange-600'
+    if (hookName.includes('thinking')) return 'text-pink-600'
+    if (hookName.includes('iteration')) return 'text-yellow-600'
+    if (hookName.includes('error')) return 'text-red-600'
+    if (hookName.includes('stop')) return 'text-gray-600'
+    return 'text-indigo-600'
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 w-96 max-h-[600px] flex flex-col">
+      <Card className="shadow-xl border-2 flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="bg-slate-900 text-white px-4 py-2 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold">🔍 Observability Hooks</span>
+            <span className="text-xs opacity-70">({events.length})</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 w-6 p-0 text-white hover:bg-slate-700"
+              onClick={clearEvents}
+              title="Clear events"
+            >
+              <Trash2 className="w-3 h-3" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 w-6 p-0 text-white hover:bg-slate-700"
+              onClick={() => setIsCollapsed(!isCollapsed)}
+            >
+              {isCollapsed ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-6 w-6 p-0 text-white hover:bg-slate-700"
+              onClick={() => setIsVisible(false)}
+            >
+              <X className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        {/* Events List */}
+        {!isCollapsed && (
+          <div className="flex-1 overflow-y-auto bg-slate-50 p-3 space-y-2" style={{ maxHeight: '500px' }}>
+            {events.length === 0 ? (
+              <div className="text-center text-sm text-muted-foreground py-8">
+                No events yet. Start a conversation to see hooks firing.
+              </div>
+            ) : (
+              events.map((event) => (
+                <div
+                  key={event.id}
+                  className="bg-white rounded-md border border-slate-200 p-2 text-xs font-mono"
+                >
+                  <div className="flex items-start justify-between mb-1">
+                    <span className={`font-semibold ${getHookColor(event.hook)}`}>
+                      {event.hook}
+                    </span>
+                    <span className="text-slate-400 text-[10px]">
+                      {new Date(event.timestamp).toLocaleTimeString()}
+                    </span>
+                  </div>
+                  <pre className="text-[10px] text-slate-600 overflow-x-auto bg-slate-50 p-2 rounded border border-slate-100">
+                    {JSON.stringify(event.payload, null, 2)}
+                  </pre>
+                </div>
+              ))
+            )}
+            <div ref={eventsEndRef} />
+          </div>
+        )}
+      </Card>
+
+      {/* Show button when panel is hidden */}
+      {!isVisible && (
+        <Button
+          onClick={() => setIsVisible(true)}
+          className="fixed bottom-4 right-4 shadow-lg"
+          size="sm"
+        >
+          🔍 Show Debug Panel
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/examples/rails_bible_chat/app/frontend/pages/Conversations/Show.tsx
+++ b/examples/rails_bible_chat/app/frontend/pages/Conversations/Show.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, Send, Loader2 } from 'lucide-react'
 import { BibleVerse } from '@/components/BibleVerse'
 import { ThinkingBlock } from '@/components/ThinkingBlock'
 import { EmojiExplosion } from '@/components/EmojiExplosion'
+import { DebugPanel } from '@/components/DebugPanel'
 import { v4 } from 'uuid'
 interface Message {
   id: number
@@ -458,6 +459,9 @@ export default function Show({ conversation, messages: initialMessages }: Props)
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
+      {/* Debug Panel */}
+      <DebugPanel conversationId={conversation.id} />
+
       {/* Emoji Explosion Animation */}
       {explodingEmoji && (
         <EmojiExplosion

--- a/examples/rails_bible_chat/config/application.rb
+++ b/examples/rails_bible_chat/config/application.rb
@@ -5,6 +5,7 @@ require "active_model/railtie"
 require "active_record/railtie"
 require "action_controller/railtie"
 require "action_view/railtie"
+require "action_cable/engine"
 
 Bundler.require(*Rails.groups)
 

--- a/examples/rails_bible_chat/config/cable.yml
+++ b/examples/rails_bible_chat/config/cable.yml
@@ -1,0 +1,10 @@
+development:
+  adapter: async
+
+test:
+  adapter: test
+
+production:
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  channel_prefix: rails_bible_chat_production

--- a/examples/rails_bible_chat/config/environments/development.rb
+++ b/examples/rails_bible_chat/config/environments/development.rb
@@ -53,4 +53,11 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # ActionCable configuration
+  config.action_cable.url = "ws://localhost:3000/cable"
+  config.action_cable.allowed_request_origins = [
+    "http://localhost:3000",
+    /http:\/\/localhost:*/
+  ]
 end

--- a/examples/rails_bible_chat/config/routes.rb
+++ b/examples/rails_bible_chat/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   root "conversations#index"
 
+  # ActionCable endpoint
+  mount ActionCable.server => '/cable'
+
   resources :conversations, only: [:index, :create, :show] do
     member do
       post :send_message

--- a/examples/rails_bible_chat/package-lock.json
+++ b/examples/rails_bible_chat/package-lock.json
@@ -8,6 +8,7 @@
         "@inertiajs/react": "^2.2.17",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-slot": "^1.2.4",
+        "@rails/actioncable": "^7.2.0",
         "@tailwindcss/vite": "^4.1.17",
         "lucide-react": "^0.553.0",
         "react": "^19.2.0",
@@ -931,6 +932,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rails/actioncable": {
+      "version": "7.2.300",
+      "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-7.2.300.tgz",
+      "integrity": "sha512-bmrp+HgCPd2BlhDfJ81hJ6Nvd6yh0B2hIW8ThOmUdOr3L+sFjU1glpBmn+MoQF2K0HLvnWCGqF3TxT/S0jj3QA=="
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.47",

--- a/examples/rails_bible_chat/package.json
+++ b/examples/rails_bible_chat/package.json
@@ -16,6 +16,7 @@
     "@inertiajs/react": "^2.2.17",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-slot": "^1.2.4",
+    "@rails/actioncable": "^7.2.0",
     "@tailwindcss/vite": "^4.1.17",
     "lucide-react": "^0.553.0",
     "react": "^19.2.0",

--- a/lib/activeintelligence.rb
+++ b/lib/activeintelligence.rb
@@ -1,5 +1,6 @@
 # lib/active_intelligence.rb
 require_relative 'activeintelligence/config'
+require_relative 'activeintelligence/callbacks'
 require_relative 'activeintelligence/agent'
 require_relative 'activeintelligence/messages'
 require_relative 'activeintelligence/api_clients/base_client'

--- a/lib/activeintelligence/api_clients/base_client.rb
+++ b/lib/activeintelligence/api_clients/base_client.rb
@@ -24,7 +24,6 @@ module ActiveIntelligence
 
       def handle_error(error, prefix = "API Error")
         message = "#{prefix}: #{error.message}"
-        binding.pry
         logger.error(message)
         message
       end

--- a/lib/activeintelligence/callbacks.rb
+++ b/lib/activeintelligence/callbacks.rb
@@ -1,0 +1,386 @@
+# lib/activeintelligence/callbacks.rb
+require 'securerandom'
+
+module ActiveIntelligence
+  # Data structures for callback payloads
+  class Session
+    attr_reader :id, :agent_class, :created_at
+    attr_accessor :ended_at, :total_turns, :total_input_tokens, :total_output_tokens
+
+    def initialize(agent_class:)
+      @id = SecureRandom.uuid
+      @agent_class = agent_class
+      @created_at = Time.now
+      @ended_at = nil
+      @total_turns = 0
+      @total_input_tokens = 0
+      @total_output_tokens = 0
+    end
+
+    def duration
+      return nil unless @ended_at
+      @ended_at - @created_at
+    end
+
+    def end!
+      @ended_at = Time.now
+    end
+
+    def to_h
+      {
+        id: @id,
+        agent_class: @agent_class,
+        created_at: @created_at,
+        ended_at: @ended_at,
+        duration: duration,
+        total_turns: @total_turns,
+        total_input_tokens: @total_input_tokens,
+        total_output_tokens: @total_output_tokens
+      }
+    end
+  end
+
+  class Turn
+    attr_reader :id, :user_message, :started_at, :session_id
+    attr_accessor :ended_at, :usage, :iteration_count
+
+    def initialize(user_message:, session_id:)
+      @id = SecureRandom.uuid
+      @user_message = user_message
+      @session_id = session_id
+      @started_at = Time.now
+      @ended_at = nil
+      @usage = Usage.new
+      @iteration_count = 0
+    end
+
+    def duration
+      return nil unless @ended_at
+      @ended_at - @started_at
+    end
+
+    def end!
+      @ended_at = Time.now
+    end
+
+    def to_h
+      {
+        id: @id,
+        session_id: @session_id,
+        user_message: @user_message,
+        started_at: @started_at,
+        ended_at: @ended_at,
+        duration: duration,
+        usage: @usage.to_h,
+        iteration_count: @iteration_count
+      }
+    end
+  end
+
+  class Response
+    attr_reader :id, :turn_id, :is_streaming, :started_at
+    attr_accessor :ended_at, :content, :usage, :stop_reason, :model, :tool_calls
+
+    def initialize(turn_id:, is_streaming: false)
+      @id = SecureRandom.uuid
+      @turn_id = turn_id
+      @is_streaming = is_streaming
+      @started_at = Time.now
+      @ended_at = nil
+      @content = nil
+      @usage = Usage.new
+      @stop_reason = nil
+      @model = nil
+      @tool_calls = []
+    end
+
+    def duration
+      return nil unless @ended_at
+      @ended_at - @started_at
+    end
+
+    def end!
+      @ended_at = Time.now
+    end
+
+    def to_h
+      {
+        id: @id,
+        turn_id: @turn_id,
+        is_streaming: @is_streaming,
+        started_at: @started_at,
+        ended_at: @ended_at,
+        duration: duration,
+        content: @content,
+        usage: @usage.to_h,
+        stop_reason: @stop_reason,
+        model: @model,
+        tool_calls: @tool_calls
+      }
+    end
+  end
+
+  class Chunk
+    attr_reader :content, :index, :response_id
+
+    def initialize(content:, index:, response_id:)
+      @content = content
+      @index = index
+      @response_id = response_id
+    end
+
+    def to_h
+      {
+        content: @content,
+        index: @index,
+        response_id: @response_id
+      }
+    end
+  end
+
+  class Thinking
+    attr_reader :response_id, :started_at
+    attr_accessor :content, :ended_at
+
+    def initialize(response_id:)
+      @response_id = response_id
+      @started_at = Time.now
+      @content = ""
+      @ended_at = nil
+    end
+
+    def duration
+      return nil unless @ended_at
+      @ended_at - @started_at
+    end
+
+    def end!
+      @ended_at = Time.now
+    end
+
+    def to_h
+      {
+        response_id: @response_id,
+        started_at: @started_at,
+        ended_at: @ended_at,
+        content: @content,
+        duration: duration
+      }
+    end
+  end
+
+  class ToolExecution
+    attr_reader :name, :tool_class, :input, :started_at, :tool_use_id
+    attr_accessor :result, :ended_at, :error
+
+    def initialize(name:, tool_class:, input:, tool_use_id:)
+      @name = name
+      @tool_class = tool_class
+      @input = input
+      @tool_use_id = tool_use_id
+      @started_at = Time.now
+      @ended_at = nil
+      @result = nil
+      @error = nil
+    end
+
+    def duration
+      return nil unless @ended_at
+      @ended_at - @started_at
+    end
+
+    def end!
+      @ended_at = Time.now
+    end
+
+    def success?
+      @error.nil? && @result && !(@result.is_a?(Hash) && @result[:error])
+    end
+
+    def to_h
+      {
+        name: @name,
+        tool_class: @tool_class,
+        input: @input,
+        tool_use_id: @tool_use_id,
+        started_at: @started_at,
+        ended_at: @ended_at,
+        duration: duration,
+        result: @result,
+        error: @error
+      }
+    end
+  end
+
+  class Usage
+    attr_accessor :input_tokens, :output_tokens, :cache_read_tokens, :cache_creation_tokens
+
+    def initialize(input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0)
+      @input_tokens = input_tokens
+      @output_tokens = output_tokens
+      @cache_read_tokens = cache_read_tokens
+      @cache_creation_tokens = cache_creation_tokens
+    end
+
+    def total_tokens
+      @input_tokens + @output_tokens
+    end
+
+    def add(other_usage)
+      return unless other_usage
+      @input_tokens += other_usage.input_tokens || 0
+      @output_tokens += other_usage.output_tokens || 0
+      @cache_read_tokens += other_usage.cache_read_tokens || 0
+      @cache_creation_tokens += other_usage.cache_creation_tokens || 0
+    end
+
+    def to_h
+      {
+        input_tokens: @input_tokens,
+        output_tokens: @output_tokens,
+        total_tokens: total_tokens,
+        cache_read_tokens: @cache_read_tokens,
+        cache_creation_tokens: @cache_creation_tokens
+      }
+    end
+  end
+
+  class Iteration
+    attr_reader :number, :tool_calls_count, :turn_id, :timestamp
+
+    def initialize(number:, tool_calls_count:, turn_id:)
+      @number = number
+      @tool_calls_count = tool_calls_count
+      @turn_id = turn_id
+      @timestamp = Time.now
+    end
+
+    def to_h
+      {
+        number: @number,
+        tool_calls_count: @tool_calls_count,
+        turn_id: @turn_id,
+        timestamp: @timestamp
+      }
+    end
+  end
+
+  class ErrorContext
+    attr_reader :error, :context
+
+    def initialize(error:, context: {})
+      @error = error
+      @context = context
+    end
+
+    def error_class
+      @error.class.to_s
+    end
+
+    def message
+      @error.message
+    end
+
+    def backtrace
+      @error.backtrace
+    end
+
+    def to_h
+      {
+        error_class: error_class,
+        message: message,
+        backtrace: backtrace&.first(10),
+        context: @context
+      }
+    end
+  end
+
+  class StopEvent
+    attr_reader :reason, :details
+
+    REASONS = {
+      max_turns: :max_turns,
+      user_stop: :user_stop,
+      error: :error,
+      complete: :complete,
+      frontend_pause: :frontend_pause
+    }.freeze
+
+    def initialize(reason:, details: {})
+      @reason = reason
+      @details = details
+    end
+
+    def to_h
+      {
+        reason: @reason,
+        details: @details
+      }
+    end
+  end
+
+  # Callbacks module to be included in Agent
+  module Callbacks
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      HOOK_NAMES = %i[
+        on_session_start
+        on_session_end
+        on_turn_start
+        on_turn_end
+        on_response_start
+        on_response_end
+        on_response_chunk
+        on_thinking_start
+        on_thinking_end
+        on_tool_start
+        on_tool_end
+        on_tool_error
+        on_message_added
+        on_iteration
+        on_error
+        on_stop
+      ].freeze
+
+      def callbacks
+        @callbacks ||= {}
+      end
+
+      # Generate DSL methods for each hook
+      HOOK_NAMES.each do |hook_name|
+        define_method(hook_name) do |method_name = nil, &block|
+          callbacks[hook_name] ||= []
+          if block
+            callbacks[hook_name] << block
+          elsif method_name
+            callbacks[hook_name] << method_name
+          end
+        end
+      end
+
+      def inherited(subclass)
+        super
+        # Copy parent callbacks to subclass
+        subclass.instance_variable_set(:@callbacks, callbacks.transform_values(&:dup))
+      end
+    end
+
+    # Instance methods for triggering callbacks
+    def trigger_callback(hook_name, *args)
+      handlers = self.class.callbacks[hook_name] || []
+      handlers.each do |handler|
+        if handler.is_a?(Symbol)
+          send(handler, *args)
+        else
+          instance_exec(*args, &handler)
+        end
+      rescue StandardError => e
+        # Don't let callback errors break the main flow
+        Config.logger&.error("Callback error in #{hook_name}: #{e.message}")
+      end
+    end
+  end
+end

--- a/spec/activeintelligence/agent_hybrid_tools_spec.rb
+++ b/spec/activeintelligence/agent_hybrid_tools_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe ActiveIntelligence::Agent, 'hybrid tools' do
       pending_tool = response[:pending_tools].first
       expect(pending_tool[:tool_use_id]).to eq("toolu_123")
       expect(pending_tool[:tool_name]).to eq("frontend_tool")
-      expect(pending_tool[:parameters]).to eq({ action: "test" })
+      expect(pending_tool[:tool_input]).to eq({ action: "test" })
     end
 
     it 'includes only pending tool responses' do

--- a/spec/activeintelligence/callbacks_spec.rb
+++ b/spec/activeintelligence/callbacks_spec.rb
@@ -1,0 +1,623 @@
+require 'spec_helper'
+
+RSpec.describe ActiveIntelligence::Callbacks do
+  describe 'data structures' do
+    describe ActiveIntelligence::Session do
+      subject(:session) { described_class.new(agent_class: 'TestAgent') }
+
+      it 'generates a unique id' do
+        expect(session.id).to be_a(String)
+        expect(session.id.length).to eq(36) # UUID format
+      end
+
+      it 'sets agent_class' do
+        expect(session.agent_class).to eq('TestAgent')
+      end
+
+      it 'initializes with zero counters' do
+        expect(session.total_turns).to eq(0)
+        expect(session.total_input_tokens).to eq(0)
+        expect(session.total_output_tokens).to eq(0)
+      end
+
+      it 'tracks duration when ended' do
+        expect(session.duration).to be_nil
+        session.end!
+        expect(session.duration).to be >= 0
+      end
+
+      it 'converts to hash' do
+        hash = session.to_h
+        expect(hash).to include(:id, :agent_class, :created_at, :total_turns)
+      end
+    end
+
+    describe ActiveIntelligence::Turn do
+      subject(:turn) { described_class.new(user_message: 'Hello', session_id: 'session-123') }
+
+      it 'generates a unique id' do
+        expect(turn.id).to be_a(String)
+      end
+
+      it 'stores user_message' do
+        expect(turn.user_message).to eq('Hello')
+      end
+
+      it 'stores session_id' do
+        expect(turn.session_id).to eq('session-123')
+      end
+
+      it 'initializes with zero iteration count' do
+        expect(turn.iteration_count).to eq(0)
+      end
+
+      it 'tracks duration when ended' do
+        expect(turn.duration).to be_nil
+        turn.end!
+        expect(turn.duration).to be >= 0
+      end
+    end
+
+    describe ActiveIntelligence::Response do
+      subject(:response) { described_class.new(turn_id: 'turn-123', is_streaming: true) }
+
+      it 'generates a unique id' do
+        expect(response.id).to be_a(String)
+      end
+
+      it 'stores turn_id and is_streaming' do
+        expect(response.turn_id).to eq('turn-123')
+        expect(response.is_streaming).to be true
+      end
+
+      it 'tracks duration when ended' do
+        expect(response.duration).to be_nil
+        response.end!
+        expect(response.duration).to be >= 0
+      end
+    end
+
+    describe ActiveIntelligence::ToolExecution do
+      subject(:tool_exec) do
+        described_class.new(
+          name: 'my_tool',
+          tool_class: 'MyTool',
+          input: { query: 'test' },
+          tool_use_id: 'toolu_123'
+        )
+      end
+
+      it 'stores tool metadata' do
+        expect(tool_exec.name).to eq('my_tool')
+        expect(tool_exec.tool_class).to eq('MyTool')
+        expect(tool_exec.input).to eq({ query: 'test' })
+        expect(tool_exec.tool_use_id).to eq('toolu_123')
+      end
+
+      it 'tracks success state' do
+        tool_exec.result = { success: true, data: {} }
+        tool_exec.end!
+        expect(tool_exec.success?).to be true
+      end
+
+      it 'tracks error state' do
+        tool_exec.error = StandardError.new('Something went wrong')
+        tool_exec.end!
+        expect(tool_exec.success?).to be false
+      end
+    end
+
+    describe ActiveIntelligence::Usage do
+      subject(:usage) { described_class.new(input_tokens: 100, output_tokens: 50) }
+
+      it 'stores token counts' do
+        expect(usage.input_tokens).to eq(100)
+        expect(usage.output_tokens).to eq(50)
+      end
+
+      it 'calculates total_tokens' do
+        expect(usage.total_tokens).to eq(150)
+      end
+
+      it 'can add another usage' do
+        other = described_class.new(input_tokens: 25, output_tokens: 25)
+        usage.add(other)
+        expect(usage.input_tokens).to eq(125)
+        expect(usage.output_tokens).to eq(75)
+      end
+    end
+
+    describe ActiveIntelligence::Chunk do
+      subject(:chunk) { described_class.new(content: 'Hello', index: 0, response_id: 'resp-123') }
+
+      it 'stores chunk data' do
+        expect(chunk.content).to eq('Hello')
+        expect(chunk.index).to eq(0)
+        expect(chunk.response_id).to eq('resp-123')
+      end
+    end
+
+    describe ActiveIntelligence::Iteration do
+      subject(:iteration) { described_class.new(number: 1, tool_calls_count: 2, turn_id: 'turn-123') }
+
+      it 'stores iteration data' do
+        expect(iteration.number).to eq(1)
+        expect(iteration.tool_calls_count).to eq(2)
+        expect(iteration.turn_id).to eq('turn-123')
+      end
+    end
+
+    describe ActiveIntelligence::ErrorContext do
+      let(:error) { StandardError.new('Test error') }
+      subject(:context) { described_class.new(error: error, context: { turn_id: '123' }) }
+
+      it 'stores error details' do
+        expect(context.error_class).to eq('StandardError')
+        expect(context.message).to eq('Test error')
+      end
+
+      it 'stores context hash' do
+        expect(context.context).to eq({ turn_id: '123' })
+      end
+    end
+
+    describe ActiveIntelligence::StopEvent do
+      subject(:event) { described_class.new(reason: :complete, details: { final: true }) }
+
+      it 'stores reason and details' do
+        expect(event.reason).to eq(:complete)
+        expect(event.details).to eq({ final: true })
+      end
+    end
+  end
+
+  describe 'callback registration and triggering' do
+    let(:test_agent_class) do
+      Class.new(ActiveIntelligence::Agent) do
+        model :claude
+        memory :in_memory
+        identity "Test agent"
+      end
+    end
+
+    describe 'block-based callbacks' do
+      it 'registers and triggers on_session_start' do
+        session_received = nil
+        test_agent_class.on_session_start { |session| session_received = session }
+
+        agent = create_agent(test_agent_class)
+
+        expect(session_received).to be_a(ActiveIntelligence::Session)
+        expect(session_received.agent_class).to eq(test_agent_class.name)
+      end
+
+      it 'registers and triggers on_session_end' do
+        session_received = nil
+        test_agent_class.on_session_end { |session| session_received = session }
+
+        agent = create_agent(test_agent_class)
+        agent.end_session
+
+        expect(session_received).to be_a(ActiveIntelligence::Session)
+        expect(session_received.ended_at).not_to be_nil
+      end
+
+      it 'registers and triggers on_turn_start' do
+        turn_received = nil
+        test_agent_class.on_turn_start { |turn| turn_received = turn }
+
+        agent = create_agent(test_agent_class)
+        mock_simple_response(agent)
+
+        agent.send_message('Hello')
+
+        expect(turn_received).to be_a(ActiveIntelligence::Turn)
+        expect(turn_received.user_message).to eq('Hello')
+      end
+
+      it 'registers and triggers on_turn_end' do
+        turn_received = nil
+        test_agent_class.on_turn_end { |turn| turn_received = turn }
+
+        agent = create_agent(test_agent_class)
+        mock_simple_response(agent)
+
+        agent.send_message('Hello')
+
+        expect(turn_received).to be_a(ActiveIntelligence::Turn)
+        expect(turn_received.ended_at).not_to be_nil
+      end
+
+      it 'registers and triggers on_response_start and on_response_end' do
+        response_started = nil
+        response_ended = nil
+
+        test_agent_class.on_response_start { |r| response_started = r }
+        test_agent_class.on_response_end { |r| response_ended = r }
+
+        agent = create_agent(test_agent_class)
+        mock_api_client_response(agent)
+
+        agent.send_message('Hello')
+
+        expect(response_started).to be_a(ActiveIntelligence::Response)
+        expect(response_ended).to be_a(ActiveIntelligence::Response)
+        expect(response_ended.ended_at).not_to be_nil
+      end
+
+      it 'registers and triggers on_message_added' do
+        messages_added = []
+        test_agent_class.on_message_added { |msg| messages_added << msg }
+
+        agent = create_agent(test_agent_class)
+        mock_simple_response(agent)
+
+        agent.send_message('Hello')
+
+        expect(messages_added.size).to eq(2) # UserMessage + AgentResponse
+        expect(messages_added[0]).to be_a(ActiveIntelligence::Messages::UserMessage)
+        expect(messages_added[1]).to be_a(ActiveIntelligence::Messages::AgentResponse)
+      end
+
+      it 'registers and triggers on_stop' do
+        stop_event = nil
+        test_agent_class.on_stop { |event| stop_event = event }
+
+        agent = create_agent(test_agent_class)
+        mock_simple_response(agent)
+
+        agent.send_message('Hello')
+
+        expect(stop_event).to be_a(ActiveIntelligence::StopEvent)
+        expect(stop_event.reason).to eq(:complete)
+      end
+    end
+
+    describe 'method-based callbacks' do
+      let(:agent_with_methods) do
+        Class.new(ActiveIntelligence::Agent) do
+          model :claude
+          memory :in_memory
+          identity "Test agent"
+
+          on_session_start :handle_session_start
+          on_turn_start :handle_turn_start
+
+          attr_reader :session_started, :turn_started
+
+          def handle_session_start(session)
+            @session_started = session
+          end
+
+          def handle_turn_start(turn)
+            @turn_started = turn
+          end
+        end
+      end
+
+      it 'calls the named method for callbacks' do
+        agent = create_agent(agent_with_methods)
+        mock_simple_response(agent)
+
+        agent.send_message('Hello')
+
+        expect(agent.session_started).to be_a(ActiveIntelligence::Session)
+        expect(agent.turn_started).to be_a(ActiveIntelligence::Turn)
+      end
+    end
+
+    describe 'callback inheritance' do
+      let(:parent_class) do
+        Class.new(ActiveIntelligence::Agent) do
+          model :claude
+          memory :in_memory
+          identity "Parent"
+
+          class << self
+            attr_accessor :parent_called
+          end
+
+          on_session_start { self.class.parent_called = true }
+        end
+      end
+
+      let(:child_class) do
+        parent = parent_class
+        Class.new(parent) do
+          class << self
+            attr_accessor :child_called
+          end
+
+          on_session_start { self.class.child_called = true }
+        end
+      end
+
+      it 'inherits parent callbacks to child' do
+        agent = create_agent(child_class)
+
+        # Both parent and child callbacks should be called
+        expect(child_class.parent_called).to be true
+        expect(child_class.child_called).to be true
+      end
+    end
+  end
+
+  describe 'tool callbacks' do
+    let(:test_tool_class) do
+      Class.new(ActiveIntelligence::Tool) do
+        execution_context :backend
+        name "test_tool"
+        description "A test tool"
+
+        param :query, type: String, required: true
+
+        def execute(params)
+          success_response({ result: "executed" })
+        end
+      end
+    end
+
+    let(:test_agent_class) do
+      tool_class = test_tool_class
+      Class.new(ActiveIntelligence::Agent) do
+        model :claude
+        memory :in_memory
+        identity "Test agent"
+        tool tool_class
+      end
+    end
+
+    it 'triggers on_tool_start and on_tool_end' do
+      tool_started = nil
+      tool_ended = nil
+
+      test_agent_class.on_tool_start { |t| tool_started = t }
+      test_agent_class.on_tool_end { |t| tool_ended = t }
+
+      agent = create_agent(test_agent_class)
+      mock_tool_response(agent)
+
+      agent.send_message('Use the tool')
+
+      expect(tool_started).to be_a(ActiveIntelligence::ToolExecution)
+      expect(tool_started.name).to eq('test_tool')
+      expect(tool_ended).to be_a(ActiveIntelligence::ToolExecution)
+      expect(tool_ended.result).to include(:success)
+    end
+
+    it 'triggers on_iteration during tool loop' do
+      iterations = []
+      test_agent_class.on_iteration { |iter| iterations << iter }
+
+      agent = create_agent(test_agent_class)
+      mock_tool_response(agent)
+
+      agent.send_message('Use the tool')
+
+      expect(iterations.size).to eq(1)
+      expect(iterations[0].number).to eq(1)
+      expect(iterations[0].tool_calls_count).to eq(1)
+    end
+  end
+
+  describe 'error callbacks' do
+    # Tool that returns an error response (caught internally by Tool class)
+    let(:failing_tool_class) do
+      Class.new(ActiveIntelligence::Tool) do
+        execution_context :backend
+        name "failing_tool"
+        description "A tool that fails"
+
+        param :query, type: String, required: true
+
+        def execute(params)
+          raise StandardError, "Tool failure!"
+        end
+      end
+    end
+
+    let(:test_agent_class) do
+      tool_class = failing_tool_class
+      Class.new(ActiveIntelligence::Agent) do
+        model :claude
+        memory :in_memory
+        identity "Test agent"
+        tool tool_class
+      end
+    end
+
+    it 'triggers on_tool_error when tool returns error response' do
+      tool_errors = []
+      test_agent_class.on_tool_error { |t| tool_errors << t }
+
+      agent = create_agent(test_agent_class)
+
+      # Mock the API client: first call returns tool_use, second returns final text
+      api_client = double('api_client')
+      agent.instance_variable_set(:@api_client, api_client)
+
+      call_count = 0
+      allow(api_client).to receive(:call) do
+        call_count += 1
+        if call_count == 1
+          {
+            content: "",
+            tool_calls: [{ id: "toolu_123", name: "failing_tool", parameters: { query: "test" } }],
+            stop_reason: "tool_use",
+            usage: nil,
+            thinking: nil,
+            model: "claude-3"
+          }
+        else
+          {
+            content: "I see the tool failed.",
+            tool_calls: [],
+            stop_reason: "end_turn",
+            usage: nil,
+            thinking: nil,
+            model: "claude-3"
+          }
+        end
+      end
+
+      # Tool errors are caught by the Tool class and returned as error responses
+      # So no exception is raised, but on_tool_error is fired
+      agent.send_message('Use the tool')
+
+      expect(tool_errors.size).to eq(1)
+      expect(tool_errors.first).to be_a(ActiveIntelligence::ToolExecution)
+      expect(tool_errors.first.result).to include(:error)
+      expect(tool_errors.first.result[:message]).to include("Tool failure!")
+    end
+
+    it 'triggers on_error for agent-level errors like max iterations' do
+      error_context = nil
+      test_agent_class.on_error { |ctx| error_context = ctx }
+
+      agent = create_agent(test_agent_class)
+
+      # Mock the API client to always return tool calls (infinite loop)
+      api_client = double('api_client')
+      agent.instance_variable_set(:@api_client, api_client)
+
+      # Use unique tool_use_ids to force loop to continue
+      call_count = 0
+      allow(api_client).to receive(:call) do
+        call_count += 1
+        {
+          content: "",
+          tool_calls: [{ id: "toolu_#{call_count}", name: "failing_tool", parameters: { query: "test" } }],
+          stop_reason: "tool_use",
+          usage: nil,
+          thinking: nil,
+          model: "claude-3"
+        }
+      end
+
+      expect { agent.send_message('Use the tool') }.to raise_error(ActiveIntelligence::Error, /Maximum tool call iterations/)
+
+      expect(error_context).to be_a(ActiveIntelligence::ErrorContext)
+      expect(error_context.message).to include("Maximum tool call iterations")
+    end
+  end
+
+  describe 'usage tracking' do
+    let(:test_agent_class) do
+      Class.new(ActiveIntelligence::Agent) do
+        model :claude
+        memory :in_memory
+        identity "Test agent"
+      end
+    end
+
+    it 'accumulates usage in session' do
+      agent = create_agent(test_agent_class)
+      mock_api_client_with_usage(agent, input: 100, output: 50)
+
+      agent.send_message('Hello')
+
+      expect(agent.session.total_input_tokens).to eq(100)
+      expect(agent.session.total_output_tokens).to eq(50)
+    end
+
+    it 'tracks usage in turn' do
+      turn_ended = nil
+      test_agent_class.on_turn_end { |t| turn_ended = t }
+
+      agent = create_agent(test_agent_class)
+      mock_api_client_with_usage(agent, input: 100, output: 50)
+
+      agent.send_message('Hello')
+
+      expect(turn_ended.usage.input_tokens).to eq(100)
+      expect(turn_ended.usage.output_tokens).to eq(50)
+    end
+
+    it 'tracks usage in response' do
+      response_ended = nil
+      test_agent_class.on_response_end { |r| response_ended = r }
+
+      agent = create_agent(test_agent_class)
+      mock_api_client_with_usage(agent, input: 100, output: 50)
+
+      agent.send_message('Hello')
+
+      expect(response_ended.usage.input_tokens).to eq(100)
+      expect(response_ended.usage.output_tokens).to eq(50)
+    end
+  end
+
+  # Helper methods
+  def create_agent(agent_class)
+    agent = agent_class.allocate
+    allow(agent).to receive(:setup_api_client)
+    agent.send(:initialize)
+    agent
+  end
+
+  def mock_simple_response(agent)
+    allow(agent).to receive(:call_api).and_return(
+      ActiveIntelligence::Messages::AgentResponse.new(
+        content: "Hello!",
+        tool_calls: []
+      )
+    )
+  end
+
+  def mock_api_client_response(agent, content: "Hello!", usage: nil)
+    api_client = double('api_client')
+    agent.instance_variable_set(:@api_client, api_client)
+
+    allow(api_client).to receive(:call).and_return({
+      content: content,
+      tool_calls: [],
+      stop_reason: "end_turn",
+      usage: usage,
+      thinking: nil,
+      model: "claude-3"
+    })
+  end
+
+  def mock_api_client_with_usage(agent, input:, output:)
+    api_client = double('api_client')
+    agent.instance_variable_set(:@api_client, api_client)
+
+    usage = ActiveIntelligence::Usage.new(input_tokens: input, output_tokens: output)
+
+    allow(api_client).to receive(:call).and_return({
+      content: "Hello!",
+      tool_calls: [],
+      stop_reason: "end_turn",
+      usage: usage,
+      thinking: nil,
+      model: "claude-3"
+    })
+  end
+
+  def mock_tool_response(agent)
+    tool_call_response = ActiveIntelligence::Messages::AgentResponse.new(
+      content: "",
+      tool_calls: [
+        { id: "toolu_123", name: "test_tool", parameters: { query: "test" } }
+      ]
+    )
+
+    final_response = ActiveIntelligence::Messages::AgentResponse.new(
+      content: "Done!",
+      tool_calls: []
+    )
+
+    allow(agent).to receive(:call_api).and_return(tool_call_response, final_response)
+  end
+
+  def mock_failing_tool_response(agent)
+    tool_call_response = ActiveIntelligence::Messages::AgentResponse.new(
+      content: "",
+      tool_calls: [
+        { id: "toolu_123", name: "failing_tool", parameters: { query: "test" } }
+      ]
+    )
+
+    allow(agent).to receive(:call_api).and_return(tool_call_response)
+  end
+end


### PR DESCRIPTION
This commit introduces a callback system for monitoring agent execution, enabling observability for AI agent workflows.

## New Features

### Session Lifecycle
- `on_session_start` / `on_session_end` - Track agent session lifecycle
- Session tracks: id, agent_class, total_turns, token usage

### Turn Lifecycle
- `on_turn_start` / `on_turn_end` - Track user message to response cycles
- Turn tracks: id, user_message, duration, usage, iteration_count

### Response Lifecycle
- `on_response_start` / `on_response_end` - Track individual API calls
- `on_response_chunk` - Stream chunks for streaming responses
- Response tracks: content, usage, stop_reason, model, tool_calls

### Thinking (Extended Thinking)
- `on_thinking_start` / `on_thinking_end` - Track Claude's thinking blocks
- Thinking tracks: content, duration

### Tool Execution
- `on_tool_start` / `on_tool_end` / `on_tool_error` - Track tool calls
- ToolExecution tracks: name, input, result, duration, error

### Additional Hooks
- `on_message_added` - Every message added to history
- `on_iteration` - Each tool loop iteration
- `on_error` - Agent-level errors with context
- `on_stop` - Completion, max_turns, error, or frontend_pause

## Data Structures
- Session, Turn, Response, Chunk, Thinking, ToolExecution
- Usage (input/output tokens, cache stats)
- Iteration, ErrorContext, StopEvent

## API Changes
- ClaudeClient now returns usage data from API responses
- Streaming format includes chunk_index for observability
- Thinking events are now yielded for callback hooks

## Usage Example
```ruby
class MyAgent < ActiveIntelligence::Agent
  on_turn_end { |turn| log_turn(turn) }
  on_tool_end { |tool| metrics.track_tool(tool) }
end

agent = MyAgent.new
agent.send_message("Hello")
agent.end_session  # Explicitly end session for metrics
```